### PR TITLE
at prepare rollout-phase, apps keep their names by convention

### DIFF
--- a/src/org/domaindrivenarchitecture/pallet/crate/liferay.clj
+++ b/src/org/domaindrivenarchitecture/pallet/crate/liferay.clj
@@ -34,7 +34,7 @@
     [org.domaindrivenarchitecture.pallet.crate.liferay.app :as liferay-app]
     [org.domaindrivenarchitecture.pallet.crate.liferay.app-config :as liferay-config]
     [org.domaindrivenarchitecture.pallet.crate.liferay.release-model :as schema]
-    ; Webserver Dependecy
+    ; Webserver Dependency
     [httpd.crate.apache2 :as apache2]
     ; Backup Dependency
     [org.domaindrivenarchitecture.pallet.crate.backup :as backup]

--- a/src/org/domaindrivenarchitecture/pallet/crate/liferay/app.clj
+++ b/src/org/domaindrivenarchitecture/pallet/crate/liferay/app.clj
@@ -144,7 +144,7 @@
         (:hooks :layouts :themes :portlets) (doseq [app (st/get-in release [key])]
                                               (let [app-name (subs (second app) (+ 1 (.lastIndexOf (second app) "/")))]
                                                 (liferay-remote-file 
-                                                  app-name
+                                                  (str dir app-name)
                                                   (second app)
                                                   :owner "root")))
         ))

--- a/src/org/domaindrivenarchitecture/pallet/crate/liferay/app.clj
+++ b/src/org/domaindrivenarchitecture/pallet/crate/liferay/app.clj
@@ -133,9 +133,10 @@
     (let [dir (str release-dir (name key) "/")]
       (liferay-dir dir :owner "root")
       (case key
-        :app (let [app (st/get-in release [:app])]
+        :app (let [app (st/get-in release [:app])
+                   app-name (subs (second app) (+ 1 (.lastIndexOf (second app) "/")))]
                (liferay-remote-file 
-                 (str dir (first app) ".war") 
+                 app-name 
                  (second app)
                  :owner "root"))
         :config (liferay-config-file

--- a/src/org/domaindrivenarchitecture/pallet/crate/liferay/app.clj
+++ b/src/org/domaindrivenarchitecture/pallet/crate/liferay/app.clj
@@ -204,7 +204,6 @@
   "creates liferay directories, copies liferay webapp into tomcat and loads dependencies into tomcat"
   (create-liferay-directories liferay-home-dir liferay-lib-dir (st/get-in liferay-release-config [:release-dir]) liferay-deploy-dir)
   (liferay-dependencies-into-tomcat liferay-lib-dir repo-download-source)
-  (liferay-dependencies-into-tomcat liferay-lib-dir repo-download-source)
   (install-do-rollout-script liferay-home-dir (st/get-in liferay-release-config [:release-dir]) liferay-deploy-dir tomcat-webapps-dir)
   )
 

--- a/src/org/domaindrivenarchitecture/pallet/crate/liferay/app.clj
+++ b/src/org/domaindrivenarchitecture/pallet/crate/liferay/app.clj
@@ -133,21 +133,23 @@
     (let [dir (str release-dir (name key) "/")]
       (liferay-dir dir :owner "root")
       (case key
-        :app (let [app (st/get-in release [:app])
-                   app-name (subs (second app) (+ 1 (.lastIndexOf (second app) "/")))]
+        :app (let [app (st/get-in release [:app])]
                (liferay-remote-file 
-                 app-name 
+                 (str dir (first app) ".war") 
                  (second app)
                  :owner "root"))
         :config (liferay-config-file
                   (str dir "portal-ext.properties") 
                   (st/get-in release [:config]))
-        (doseq [app (st/get-in release [key])]
-          (liferay-remote-file 
-            (str dir (first app) ".war") 
-            (second app)
-            :owner "root"))))
+        (:hooks :layouts :themes :portlets) (doseq [app (st/get-in release [key])]
+                                              (let [app-name (subs (second app) (+ 1 (.lastIndexOf (second app) "/")))]
+                                                (liferay-remote-file 
+                                                  app-name
+                                                  (second app)
+                                                  :owner "root")))
+        ))
     ))
+
 
 (s/defn ^:always-validate install-do-rollout-script
   "Creates script for rolling liferay version. To be called by the admin connected to the server via ssh"

--- a/test/org/domaindrivenarchitecture/pallet/crate/liferay/app_test.clj
+++ b/test/org/domaindrivenarchitecture/pallet/crate/liferay/app_test.clj
@@ -60,38 +60,54 @@
 (deftest test-good-download-and-store
   "test the good case"
   []
-  (testing 
-    "one app"
+   (testing 
+    "one app: portal - fixed name"
     (is 
       (.contains 
         (tu/extract-nth-action-command
           (build-actions/build-actions
             build-actions/ubuntu-session         
             (sut/download-and-store-applications "/somedir/"
-                                                 (c/complete {:app ["appId" "http://url/app.6.0.1.war"]} schema/LiferayRelease) 
+                                                 (c/complete {:app ["appname" "http://url"]} schema/LiferayRelease) 
                                                  :app))
              1)
-        "app.6.0.1.war"
+        "appname.war"
         )))
   (testing 
-    "multi app"
+    "one app: portlet - name by convention"
     (let [actions (build-actions/build-actions
             build-actions/ubuntu-session         
             (sut/download-and-store-applications "/somedir/" 
                                                  (c/complete
-                                                   {:portlets [["appId1" "http://url/app1.6.0.1.war"]
-                                                    ["appId2" "http://urls/app2.6.0.2.war"]]}
+                                                   {:portlets [["portletA" "url/portletA.6.2.0.1.war"]]}
                                                    schema/LiferayRelease) 
                                                  :portlets))]
       (is 
         (.contains 
           (tu/extract-nth-action-command actions 1)
-          "app1.6.0.1.war"
+          "portletA.6.2.0.1.war"
+          ))
+    ))
+  (testing 
+    "two apps: portlets - name by convention"
+    (let [actions (build-actions/build-actions
+            build-actions/ubuntu-session         
+            (sut/download-and-store-applications "/somedir/" 
+                                                 (c/complete
+                                                   {:portlets 
+                                                    [["portletA" "url/portletA.6.2.0.1.war"]
+                                                     ["portletB" "url/portletB.6.2.0.1.war"]]}
+                                                   schema/LiferayRelease) 
+                                                 :portlets))]
+      (is 
+        (.contains 
+          (tu/extract-nth-action-command actions 1)
+          "portletA.6.2.0.1.war"
           ))
       (is 
         (.contains 
           (tu/extract-nth-action-command actions 2)
-          "app2.6.0.2.war"
+          "portletB.6.2.0.1.war"
           ))
     ))
   )

--- a/test/org/domaindrivenarchitecture/pallet/crate/liferay/app_test.clj
+++ b/test/org/domaindrivenarchitecture/pallet/crate/liferay/app_test.clj
@@ -68,10 +68,10 @@
           (build-actions/build-actions
             build-actions/ubuntu-session         
             (sut/download-and-store-applications "/somedir/"
-                                                 (c/complete {:app ["appname" "http://url"]} schema/LiferayRelease) 
+                                                 (c/complete {:app ["appId" "http://url/app.6.0.1.war"]} schema/LiferayRelease) 
                                                  :app))
              1)
-        "appname.war"
+        "app.6.0.1.war"
         )))
   (testing 
     "multi app"
@@ -79,19 +79,19 @@
             build-actions/ubuntu-session         
             (sut/download-and-store-applications "/somedir/" 
                                                  (c/complete
-                                                   {:portlets [["appname1" "url"]
-                                                    ["appname2" "url"]]}
+                                                   {:portlets [["appId1" "http://url/app1.6.0.1.war"]
+                                                    ["appId2" "http://urls/app2.6.0.2.war"]]}
                                                    schema/LiferayRelease) 
                                                  :portlets))]
       (is 
         (.contains 
           (tu/extract-nth-action-command actions 1)
-          "appname1.war"
+          "app1.6.0.1.war"
           ))
       (is 
         (.contains 
           (tu/extract-nth-action-command actions 2)
-          "appname2.war"
+          "app2.6.0.2.war"
           ))
     ))
   )


### PR DESCRIPTION
Liferay apps should keep their original names; otherwise, deploying them will cause versioning issues.
I only changed the remote file name which should not influence the rest of the code. 